### PR TITLE
Updated NWIS groundwater levels to read JSON format; fixed extra newline when writing to csv with Windows

### DIFF
--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -35,6 +35,7 @@ def parse_rdb(text):
     """'
     Parses rdb tab-delimited responses for NWIS Site Services
     """
+
     def line_generator():
         header = None
         for line in text.split("\n"):
@@ -68,8 +69,8 @@ def parse_json(data):
                 "site_code": site_code,
                 "value": value["value"],
                 "date_measured": value["dateTime"].split("T")[0],
-                "time_measured": value["dateTime"].split("T")[1]
-                }
+                "time_measured": value["dateTime"].split("T")[1],
+            }
             records.append(record)
     return records
 
@@ -146,7 +147,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
         data = self._execute_json_request(
             url="https://waterservices.usgs.gov/nwis/gwlevels/",
             params=params,
-            tag="value"
+            tag="value",
         )
         if data:
             records = parse_json(data)

--- a/backend/persister.py
+++ b/backend/persister.py
@@ -108,7 +108,7 @@ class BasePersister(Loggable):
 
 
 def write_file(path, func):
-    with open(path, "w") as f:
+    with open(path, "w", newline="") as f:
         func(csv.writer(f))
 
 

--- a/backend/source.py
+++ b/backend/source.py
@@ -80,7 +80,7 @@ class BaseSource:
             return ""
 
     def _execute_json_request(self, url, params=None, tag=None, **kw):
-        print(url)
+        # print(url)
         resp = httpx.get(url, params=params, **kw)
         if tag is None:
             tag = "data"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 geopandas
 frost_sta_client
 google-cloud-storage
+pytest


### PR DESCRIPTION
- NWIS now reports groundwater levels data as a JSON, replacing the rdb format. This change parses the JSON file and maintains the DIE format
- When writing to a csv with windows `newline=""` needs to be specified, otherwise an extra newline is added