### PR TITLE
Updated logging | Updated timeseries flags | Excel-style dates | Removal of records with invalid location data | Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This package provides a command line interface to New Mexico Water Data Initiaiv
    - Pecos Valley Artesian Conservancy District
    - Elephant Butte Irrigation District
    - Bernalillo County
+   - New Mexico Environment Department Drinking Water Bureau
  - [NM Water Data CKAN catalog](https://catalog.newmexicowaterdata.org/)
    - OSE Roswell District Office
  - ISC Seven Rivers

--- a/README.md
+++ b/README.md
@@ -106,12 +106,18 @@ The follow data sources are available for analytes, though not every source has 
 ## Usage
 The data is saved to the current working directory. A log of the inputs and processes, called `die.log`, is also saved to the current working directory. If a subsquent process is run and the log from the previous process has not been moved or stored elsewhere, the log for the subsequent process will be appended to the existing log.
 
-### Timeseries & Summary
+### Timeseries Data
 The flag `--separated_timeseries` exports timeseries for every location in their own file in the directory output_series (e.g. `AB-0002.csv`, `AB-0003.csv`). Locations with only one observation are gathered and exported to the file `output.combined.csv`.
 
 The flag `--unified_timeseries` exports all timeseries for all locations in one file titled `output.timeseries.csv`. It also exports a file titled `output.sites.csv` that contains site information, such as latitude, longitude, and elevation.
 
+#### Table Headers: Unified
+
+### Summary Data
+
 If neither of the above flags are specified, a summary table called `output.csv` is exported. The summary table consists of location information as well as summary statistics for the parameter of interest for every location that has observations.
+
+#### Table Headers
 
 ### Geographic Filters
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,19 @@
 
 
 ![NMWDI](https://newmexicowaterdata.org/wp-content/uploads/2023/11/newmexicowaterdatalogoNov2023.png)
-![NMBGMR](https://waterdata.nmt.edu/static/nmbgmr_logo_resized.png)
+![NMBGMR](https://waterdata.nmt.edu/latest/static/nmbgmr_logo_resized.png)
 
 
 This package provides a command line interface to New Mexico Water Data Initiaive's Data Integration Engine. This tool is used to integrate the water data from multiple sources.
 
+## Installation
+```bash
+pip install nmuwd
+```
 
 ## Sources
+Data comes from the following sources. We are continuously adding new sources as we learn of them and they become available. If you have data that you would like to be part of the Data Integration Engine please get in touch at newmexicowaterdata@nmt.edu.
+
  - [Bureau of Reclamation](https://data.usbr.gov/) 
  - [USGS (NWIS)](https://waterdata.usgs.gov/nwis)
  - [ST2 (NMWDI)](https://st2.newmexicowaterdata.org/FROST-Server/v1.1/)
@@ -27,70 +33,53 @@ This package provides a command line interface to New Mexico Water Data Initiaiv
    - EPA
    - and over 400 state, federal, tribal, and local agencies
 
-## Installation
 
-```bash
-pip install nmuwd
-```
+### Source Inclusion & Exclusion
+The Data Integration Engine enables the user to obtain groundwater level and groundwater quality data from a variety of sources. Data from sources are included in the output unless sources are specifically excluded. The following flags are available to exclude a specific data source:
 
-## Usage
-
-### Timeseries & Summary
-The flag `--separate_timeseries_files` exports timeseries for every location in their own file in the directory output_series (e.g. AB-0002.csv, AB-0003.csv). Locations with only one observation are gathered and exported to the file `output.combined.csv.
-
-The flag `--single_timeseries_file` exports all timeseries for all locations in one file titled output.timeseries.csv. It also exports a file titled output.sites.csv that contains site information, such as latitude, longitude, and elevation.
-
-If neither of the above flags are specified, a summary table called output.csv is exported.
+- `--no-amp` to exclude New Mexico Bureau of Geology and Mineral Resources Aquifer Mapping Program (AMP) data
+- `--no-bor` to exclude Bureaof of Reclamation data
+- `--no-nwis` to exclude USGS NWIS data
+- `--no-pvacd` to exclude Pecos Valley Artesian Convservancy District (PVACD) data
+- `--no-isc-seven-rivers` to exclude Interstate Stream Commission (ISC) Seven Rivers data
+- `--no-wqp` to exclude Water Quality Portal (WQP) data
+- `--no-ckan` to exclude NM OSE Roswell data that is hosted on CKAN
+- `--no-dwb` to exclude New Mexico Environment Department Drinking Water Bureau (DWB) data
+- `--no-bernco` to exclude Bernalillo County (BernCo) data
 
 ### Water Levels
 
-Get water levels for a county. Return a summary csv
-```bash
-weave waterlevels --county eddy
+To obtain groundwater levels, use 
+
 ```
-Get water levels for a bounding box. Return a summary csv
-```bash
-weave waterlevels --bbox -106.5 32.5 -106.0 33.0
+weave waterlevels
 ```
 
+followed by the desired output type, source filters, date filters, geographic filters, and excluded data sources.
 
-Get water levels for a county. Return timeseries of water levels for each site
-```bash
-weave waterlevels --county eddy --timeseries
-```
+#### Available Data Sources
+The following data sources are available for groundwater levels:
 
-Exclude a specific data source
-```bash
-weave waterlevels --county eddy --no-amp
-```
-
-Exclude multiple data sources
-```bash
-weave waterlevels --county eddy --no-amp --no-nwis
-```
-
-Available data source flags:
- - --no-amp
- - --no-bor
- - --no-ckan
- - --no-dwb
- - --no-isc-seven-rivers
- - --no-nwis
- - --no-pvacd
- - --no-wqp
- - --no-bernco
-
-
+- amp
+- bor
+- ckan
+- dwb
+- isc-seven-rivers
+- nwis
+- pvacd
+- bernco
 
 ### Water Quality
-```bash
-weave analytes TDS --county eddy
+To obtain groundwater quality, use
+
 ```
-```bash
-weave analytes TDS --county eddy --no-bor
+weave analytes {analyte}
 ```
 
-Available analytes:
+where `{analyte}` is the name of the analyte whose data is to be retrieved.
+
+#### Available Analytes
+The following analytes are currently available for retrieval:
 - Arsenic
 - Bicarbonate
 - Calcium
@@ -105,3 +94,45 @@ Available analytes:
 - Sulfate
 - TDS
 - Uranium
+
+#### Available Data Sources
+The follow data sources are available for analytes, though not every source has measurements for every analyte:
+- bor
+- wqp
+- isc-seven-rivers
+- amp
+- dwb
+
+## Usage
+The data is saved to the current working directory. A log of the inputs and processes, called `die.log`, is also saved to the current working directory. If a subsquent process is run and the log from the previous process has not been moved or stored elsewhere, the log for the subsequent process will be appended to the existing log.
+
+### Timeseries & Summary
+The flag `--separated_timeseries` exports timeseries for every location in their own file in the directory output_series (e.g. `AB-0002.csv`, `AB-0003.csv`). Locations with only one observation are gathered and exported to the file `output.combined.csv`.
+
+The flag `--unified_timeseries` exports all timeseries for all locations in one file titled `output.timeseries.csv`. It also exports a file titled `output.sites.csv` that contains site information, such as latitude, longitude, and elevation.
+
+If neither of the above flags are specified, a summary table called `output.csv` is exported. The summary table consists of location information as well as summary statistics for the parameter of interest for every location that has observations.
+
+### Geographic Filters
+
+The following flags can be used to geographically filter data:
+
+```
+-- county {county name}
+```
+
+```
+-- bbox 'x1 y1, x2 y2'
+```
+
+### Date Filters
+
+The following flags can be used to filter by dates:
+
+```
+--start-date YYYY-MM-DD 
+```
+
+```
+--end-date YYYY-MM-DD
+```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Data comes from the following sources. We are continuously adding new sources as
 
 
 ### Source Inclusion & Exclusion
-The Data Integration Engine enables the user to obtain groundwater level and groundwater quality data from a variety of sources. Data from sources are included in the output unless sources are specifically excluded. The following flags are available to exclude a specific data source:
+The Data Integration Engine enables the user to obtain groundwater level and groundwater quality data from a variety of sources. Data from sources are included in the output unless specifically excluded. The following flags are available to exclude a specific data source:
 
 - `--no-amp` to exclude New Mexico Bureau of Geology and Mineral Resources Aquifer Mapping Program (AMP) data
 - `--no-bor` to exclude Bureaof of Reclamation data

--- a/README.md
+++ b/README.md
@@ -103,22 +103,6 @@ The follow data sources are available for analytes, though not every source has 
 - amp
 - dwb
 
-## Usage
-The data is saved to the current working directory. A log of the inputs and processes, called `die.log`, is also saved to the current working directory. If a subsquent process is run and the log from the previous process has not been moved or stored elsewhere, the log for the subsequent process will be appended to the existing log.
-
-### Timeseries Data
-The flag `--separated_timeseries` exports timeseries for every location in their own file in the directory output_series (e.g. `AB-0002.csv`, `AB-0003.csv`). Locations with only one observation are gathered and exported to the file `output.combined.csv`.
-
-The flag `--unified_timeseries` exports all timeseries for all locations in one file titled `output.timeseries.csv`. It also exports a file titled `output.sites.csv` that contains site information, such as latitude, longitude, and elevation.
-
-#### Table Headers: Unified
-
-### Summary Data
-
-If neither of the above flags are specified, a summary table called `output.csv` is exported. The summary table consists of location information as well as summary statistics for the parameter of interest for every location that has observations.
-
-#### Table Headers
-
 ### Geographic Filters
 
 The following flags can be used to geographically filter data:
@@ -142,3 +126,122 @@ The following flags can be used to filter by dates:
 ```
 --end-date YYYY-MM-DD
 ```
+
+## Output
+The data is saved to the current working directory. A log of the inputs and processes, called `die.log`, is also saved to the current working directory. If a subsquent process is run and the log from the previous process has not been moved or stored elsewhere, the log for the subsequent process will be appended to the existing log.
+
+### Timeseries Data
+The flag `--separated_timeseries` exports timeseries for every location in their own file in the directory output_series (e.g. `AB-0002.csv`, `AB-0003.csv`). Locations with only one observation are gathered and exported to the file `output.combined.csv`.
+
+The flag `--unified_timeseries` exports all timeseries for all locations in one file titled `output.timeseries.csv`. It also exports a file titled `output.sites.csv` that contains site information, such as latitude, longitude, and elevation.
+
+#### Table Headers: Unified
+
+The table headers for unified timeseries data are as follows:
+
+**output.sites.csv**
+- `source`: the organization/source for the site
+- `id`: the id of the site. The id is used as the key to join the output.timeseries.csv table
+- `name`: the colloquial name for the site if it exists
+- `latitude`: latitude in decimal degrees
+- `longitude`: the longitude in decimal degrees
+- `elevation` ground surface elevation of the site in feet
+- `elevation_units`: the units of the ground surface elevation. Defaults to ft
+- `horizontal_datum`: horizontal datum of the latitude and longitude. Defaults to WGS84
+- `vertical_datum`: the vertical datum of the elevation
+- `usgs_site_id`: USGS site id if it exists
+- `alternate_site_id`: alternate site id if it exists
+- `formation`: geologic formation in which the well terminates if it exists
+- `aquifer`: aquifer from which the well draws water if it exists
+- `well_depth`: depth of well if it exists
+
+**output.timeseries.csv - waterlevels**
+- `source`: the organization/sources for the site
+- `id`: the id of the site. The id is used as the key to join the output.sites.csv table
+- `depth_to_water_ft_below_ground_surface`: depth to water below ground surface in ft
+- `date_measured`: date of measurement in YYYY-MM-DD format
+- `time_measured`: time of measurement if it exists
+
+**output.timeseries.csv - analytes**
+- `source`: the organization/sources for the site
+- `id`: the id of the site. The id is used as the key to join the output.sites.csv table
+- `parameter`: the name of the analyte whose measurements are reported in the table. This corresponds the requested analyte
+- `parameter_value`: value of the measurement
+- `parameter_units`: units of the measurement
+- `date_measured`: date of measurement in YYYY-MM-DD format
+- `time_measured`: time of measurement if it exists
+
+#### Table Headers: Separated
+
+The files for the individual sites contain the same headers as **output.timeseries.csv** from the unified time series tables.
+
+**output.combined.csv - waterlevels**
+- `source`: the organization/source for the site
+- `id`: the id of the site. The id is used as the key to join the output.timeseries.csv table
+- `name`: the colloquial name for the site if it exists
+- `latitude`: latitude in decimal degrees
+- `longitude`: the longitude in decimal degrees
+- `elevation` ground surface elevation of the site in feet
+- `elevation_units`: the units of the ground surface elevation. Defaults to ft
+- `horizontal_datum`: horizontal datum of the latitude and longitude. Defaults to WGS84
+- `vertical_datum`: the vertical datum of the elevation
+- `usgs_site_id`: USGS site id if it exists
+- `alternate_site_id`: alternate site id if it exists
+- `formation`: geologic formation in which the well terminates if it exists
+- `aquifer`: aquifer from which the well draws water if it exists
+- `well_depth`: depth of well if it exists
+- `depth_to_water_ft_below_ground_surface`: depth to water below ground surface in ft
+- `date_measured`: date of measurement in YYYY-MM-DD format
+- `time_measured`: time of measurement if it exists
+
+**output.combined.csv - analytes**
+- `source`: the organization/source for the site
+- `id`: the id of the site. The id is used as the key to join the output.timeseries.csv table
+- `name`: the colloquial name for the site if it exists
+- `latitude`: latitude in decimal degrees
+- `longitude`: the longitude in decimal degrees
+- `elevation` ground surface elevation of the site in feet
+- `elevation_units`: the units of the ground surface elevation. Defaults to ft
+- `horizontal_datum`: horizontal datum of the latitude and longitude. Defaults to WGS84
+- `vertical_datum`: the vertical datum of the elevation
+- `usgs_site_id`: USGS site id if it exists
+- `alternate_site_id`: alternate site id if it exists
+- `formation`: geologic formation in which the well terminates if it exists
+- `aquifer`: aquifer from which the well draws water if it exists
+- `well_depth`: depth of well if it exists
+- `parameter`: the name of the analyte whose measurements are reported in the table. This corresponds the requested analyte
+- `parameter_value`: value of the measurement
+- `parameter_units`: units of the measurement
+- `date_measured`: date of measurement in YYYY-MM-DD format
+- `time_measured`: time of measurement if it exists
+
+### Summary Data
+
+If neither of the above flags are specified, a summary table called `output.csv` is exported. The summary table consists of location information as well as summary statistics for the parameter of interest for every location that has observations.
+
+#### Table Headers: Summary
+
+**output.csv - waterlevels and analytes**
+- `source`: the organization/source for the site
+- `id`: the id of the site. The id is used as the key to join the output.timeseries.csv table
+- `location`: the colloquial name for the site if it exists
+- `usgs_site_id`: USGS site id if it exists
+- `alternate_site_id`: alternate site id if it exists
+- `latitude`: latitude in decimal degrees
+- `longitude`: the longitude in decimal degrees
+- `horizontal_datum`: horizontal datum of the latitude and longitude. Defaults to WGS84
+- `elevation` ground surface elevation of the site in feet
+- `elevation_units`: the units of the ground surface elevation. Defaults to ft
+- `well_depth`: depth of well if it exists
+- `well_depth_units`: units of well depth. Defaults to ft
+- `parameter`: the name of the analyte whose measurements are reported in the table. This corresponds the requested analyte
+- `parameter_value`: value of the measurement
+- `parameter_units`: units of the measurement
+- `nrecords`: the number of records for the site
+- `min`: the minimum record for the site
+- `max`: the maximum record for the site
+- `mean`: the mean value for the records at the site
+- `most_recent_date`: date of most recent record
+- `most_recent_time`: time of most recent record if it exists
+- `most_recent_value` the value of the most recent record
+- `most_recent_units`: the units of the most recent record

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This package provides a command line interface to New Mexico Water Data Initiaiv
  - [USGS (NWIS)](https://waterdata.usgs.gov/nwis)
  - [ST2 (NMWDI)](https://st2.newmexicowaterdata.org/FROST-Server/v1.1/)
    - Pecos Valley Artesian Conservancy District
-   - Elephant Butte Irrigation District
    - Bernalillo County
    - New Mexico Environment Department Drinking Water Bureau
  - [NM Water Data CKAN catalog](https://catalog.newmexicowaterdata.org/)

--- a/backend/config.py
+++ b/backend/config.py
@@ -330,7 +330,6 @@ class Config(Loggable):
             s = ""
             self.log(s)
 
-
         s = "---- Begin configuration -------------------------------------\n"
         self.log(s)
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -18,8 +18,9 @@ import sys
 import time
 from datetime import datetime, timedelta
 
-import click
 import shapely.wkt
+
+from backend.logging import Loggable
 
 from .bounding_polygons import get_county_polygon
 from .connectors.nmbgmr.source import (
@@ -91,7 +92,7 @@ def get_source(source):
     return None
 
 
-class Config(object):
+class Config(Loggable):
     site_limit: int = 0
     dry: bool = False
 
@@ -135,10 +136,10 @@ class Config(object):
     use_csv: bool = True
     use_geojson: bool = False
 
-    logs: list = []
-    warnings: list = []
-
     def __init__(self, model=None, payload=None):
+        # need to initialize logger
+        super().__init__()
+
         self.bbox = {}
         if model:
             if model.wkt:
@@ -316,32 +317,22 @@ class Config(object):
         # return current time in milliseconds
         return int((datetime.now() - td).timestamp() * 1000)
 
-    def report(self, log_report: bool = False):
+    def report(self):
         def _report_attributes(title, attrs):
             s = f"---- {title} --------------------------------------------------"
-            click.secho(s, fg="yellow")
-            if log_report:
-                self.logs.append(s)
+            self.log(s)
 
             for k in attrs:
                 v = getattr(self, k)
                 s = f"{k}: {v}"
-                click.secho(s, fg="yellow")
-
-                if log_report:
-                    self.logs.append(s)
+                self.log(s)
 
             s = ""
-            click.secho(s, fg="yellow")
+            self.log(s)
 
-            if log_report:
-                self.logs.append(s)
 
         s = "---- Begin configuration -------------------------------------\n"
-        click.secho(s, fg="yellow")
-
-        if log_report:
-            self.logs.append(s)
+        self.log(s)
 
         sources = [f"use_source_{s}" for s in SOURCE_KEYS]
         attrs = [
@@ -373,26 +364,23 @@ class Config(object):
         )
 
         s = "---- End configuration -------------------------------------\n"
-        click.secho(s, fg="yellow")
-
-        if log_report:
-            self.logs.append(s)
+        self.log(s)
 
     def validate(self):
         if not self._validate_bbox():
-            click.secho("Invalid bounding box", fg="red")
+            self.warn("Invalid bounding box")
             sys.exit(2)
 
         if not self._validate_county():
-            click.secho("Invalid county", fg="red")
+            self.warn("Invalid county")
             sys.exit(2)
 
         if not self._validate_date(self.start_date):
-            click.secho(f"Invalid start date {self.start_date}", fg="red")
+            self.warn(f"Invalid start date {self.start_date}")
             sys.exit(2)
 
         if not self._validate_date(self.end_date):
-            click.secho("Invalid end date", fg="red")
+            self.warn(f"Invalid end date {self.end_date}")
             sys.exit(2)
 
     def _extract_date(self, d):

--- a/backend/config.py
+++ b/backend/config.py
@@ -366,6 +366,7 @@ class Config(object):
                 "output_dir",
                 "output_name",
                 "output_summary",
+                "output_single_timeseries",
                 "output_horizontal_datum",
                 "output_elevation_units",
             ),

--- a/backend/connectors/bor/source.py
+++ b/backend/connectors/bor/source.py
@@ -77,7 +77,7 @@ class BORAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_units(self, records):
         return [ri["attributes"]["resultAttributes"]["units"] for ri in records]
-    
+
     def _extract_parameter_dates(self, records):
         return [parse_dt(ri["attributes"]["dateTime"]) for ri in records]
 

--- a/backend/connectors/bor/source.py
+++ b/backend/connectors/bor/source.py
@@ -77,6 +77,9 @@ class BORAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_units(self, records):
         return [ri["attributes"]["resultAttributes"]["units"] for ri in records]
+    
+    def _extract_parameter_dates(self, records):
+        return [parse_dt(ri["attributes"]["dateTime"]) for ri in records]
 
     def _extract_most_recent(self, rs):
 

--- a/backend/connectors/ckan/source.py
+++ b/backend/connectors/ckan/source.py
@@ -125,6 +125,9 @@ class OSERoswellWaterLevelSource(OSERoswellSource, BaseWaterLevelSource):
     def _extract_most_recent(self, records):
         record = get_most_recent(records, tag="Date")
         return {"value": record["DTWGS"], "datetime": record["Date"], "units": FEET}
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [r["Date"] for r in records]
 
     def _extract_parameter_record(self, record):
         record[DTW] = float(record["DTWGS"])

--- a/backend/connectors/ckan/source.py
+++ b/backend/connectors/ckan/source.py
@@ -134,7 +134,7 @@ class OSERoswellWaterLevelSource(OSERoswellSource, BaseWaterLevelSource):
         record[DT_MEASURED] = record["Date"]
         record[DTW_UNITS] = FEET
         return record
-    
+
     def _clean_records(self, records: list) -> list:
         return [r for r in records if r["DTWGS"] is not None and r["Date"] is not None]
 

--- a/backend/connectors/ckan/source.py
+++ b/backend/connectors/ckan/source.py
@@ -125,7 +125,7 @@ class OSERoswellWaterLevelSource(OSERoswellSource, BaseWaterLevelSource):
     def _extract_most_recent(self, records):
         record = get_most_recent(records, tag="Date")
         return {"value": record["DTWGS"], "datetime": record["Date"], "units": FEET}
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [r["Date"] for r in records]
 

--- a/backend/connectors/ckan/source.py
+++ b/backend/connectors/ckan/source.py
@@ -134,6 +134,9 @@ class OSERoswellWaterLevelSource(OSERoswellSource, BaseWaterLevelSource):
         record[DT_MEASURED] = record["Date"]
         record[DTW_UNITS] = FEET
         return record
+    
+    def _clean_records(self, records: list) -> list:
+        return [r for r in records if r["DTWGS"] is not None and r["Date"] is not None]
 
 
 # ============= EOF =============================================

--- a/backend/connectors/isc_seven_rivers/source.py
+++ b/backend/connectors/isc_seven_rivers/source.py
@@ -46,6 +46,7 @@ from backend.source import (
     get_analyte_search_param,
 )
 
+
 def get_date_range(config):
     params = {}
 
@@ -61,6 +62,7 @@ def get_date_range(config):
 
 def get_datetime(record):
     return datetime.fromtimestamp(record["dateTime"] / 1000)
+
 
 def _make_url(endpoint):
     return f"https://nmisc-wf.gladata.com/api/{endpoint}"
@@ -123,7 +125,7 @@ class ISCSevenRiversAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_units(self, records):
         return [r["units"] for r in records]
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [get_datetime(r) for r in records]
 
@@ -173,7 +175,7 @@ class ISCSevenRiversWaterLevelSource(BaseWaterLevelSource):
         return [
             r["depthToWaterFeet"] for r in records if not r["invalid"] and not r["dry"]
         ]
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [get_datetime(r) for r in records]
 

--- a/backend/connectors/isc_seven_rivers/source.py
+++ b/backend/connectors/isc_seven_rivers/source.py
@@ -46,6 +46,21 @@ from backend.source import (
     get_analyte_search_param,
 )
 
+def get_date_range(config):
+    params = {}
+
+    def to_milliseconds(dt):
+        return int(dt.timestamp() * 1000)
+
+    if config.start_date:
+        params["start"] = to_milliseconds(config.start_dt)
+    if config.end_date:
+        params["end"] = to_milliseconds(config.end_dt)
+    return params
+
+
+def get_datetime(record):
+    return datetime.fromtimestamp(record["dateTime"] / 1000)
 
 def _make_url(endpoint):
     return f"https://nmisc-wf.gladata.com/api/{endpoint}"
@@ -108,6 +123,9 @@ class ISCSevenRiversAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_units(self, records):
         return [r["units"] for r in records]
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [get_datetime(r) for r in records]
 
     def get_records(self, site_record):
         config = self.config
@@ -124,23 +142,6 @@ class ISCSevenRiversAnalyteSource(BaseAnalyteSource):
             return self._execute_json_request(
                 _make_url("getReadings.ashx"), params=params
             )
-
-
-def get_date_range(config):
-    params = {}
-
-    def to_milliseconds(dt):
-        return int(dt.timestamp() * 1000)
-
-    if config.start_date:
-        params["start"] = to_milliseconds(config.start_dt)
-    if config.end_date:
-        params["end"] = to_milliseconds(config.end_dt)
-    return params
-
-
-def get_datetime(record):
-    return datetime.fromtimestamp(record["dateTime"] / 1000)
 
 
 class ISCSevenRiversWaterLevelSource(BaseWaterLevelSource):
@@ -172,6 +173,9 @@ class ISCSevenRiversWaterLevelSource(BaseWaterLevelSource):
         return [
             r["depthToWaterFeet"] for r in records if not r["invalid"] and not r["dry"]
         ]
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [get_datetime(r) for r in records]
 
     def _extract_most_recent(self, records):
         record = get_most_recent(records, "dateTime")

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -139,6 +139,9 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_results(self, records):
         return [r["SampleValue"] for r in records]
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [r["info"]["CollectionDate"] for r in records]
 
     def _extract_parameter_record(self, record):
         record[PARAMETER] = self.config.analyte
@@ -168,6 +171,9 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
             "datetime": (record["DateMeasured"], record["TimeMeasured"]),
             "units": FEET,
         }
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [(r["DateMeasured"], r["TimeMeasured"]) for r in records]
 
     def _extract_parameter_results(self, records):
         return [r["DepthToWaterBGS"] for r in records]

--- a/backend/connectors/nmbgmr/source.py
+++ b/backend/connectors/nmbgmr/source.py
@@ -139,7 +139,7 @@ class NMBGMRAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_results(self, records):
         return [r["SampleValue"] for r in records]
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [r["info"]["CollectionDate"] for r in records]
 
@@ -171,7 +171,7 @@ class NMBGMRWaterLevelSource(BaseWaterLevelSource):
             "datetime": (record["DateMeasured"], record["TimeMeasured"]),
             "units": FEET,
         }
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [(r["DateMeasured"], r["TimeMeasured"]) for r in records]
 

--- a/backend/connectors/nmenv/source.py
+++ b/backend/connectors/nmenv/source.py
@@ -126,6 +126,9 @@ class DWBAnalyteSource(STAnalyteSource):
         # this is only used in summary output
         return [r["datastream"].unit_of_measurement.symbol for r in records]
 
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [r["observation"].phenomenon_time for r in records]
+
     def _extract_most_recent(self, records):
         # this is only used in summary output
         record = get_most_recent(

--- a/backend/connectors/nmose/source.py
+++ b/backend/connectors/nmose/source.py
@@ -1,0 +1,2 @@
+import os 
+from backend.source import BaseSiteSource

--- a/backend/connectors/nmose/source.py
+++ b/backend/connectors/nmose/source.py
@@ -1,2 +1,2 @@
-import os 
+import os
 from backend.source import BaseSiteSource

--- a/backend/connectors/st2/source.py
+++ b/backend/connectors/st2/source.py
@@ -87,7 +87,7 @@ class ST2WaterLevelSource(STWaterLevelSource):
 
     def _extract_parameter_results(self, records):
         return [r["observation"].result for r in records]
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [r["observation"].phenomenon_time for r in records]
 

--- a/backend/connectors/st2/source.py
+++ b/backend/connectors/st2/source.py
@@ -87,6 +87,9 @@ class ST2WaterLevelSource(STWaterLevelSource):
 
     def _extract_parameter_results(self, records):
         return [r["observation"].result for r in records]
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [r["observation"].phenomenon_time for r in records]
 
     def _clean_records(self, records: list) -> list:
         rs = [r for r in records if r["observation"].result is not None]

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -163,6 +163,9 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
 
     def _extract_parameter_results(self, records):
         return [float(r["value"]) for r in records]
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        return [r["datetime_measured"] for r in records]
 
     def _extract_most_recent(self, records):
         record = get_most_recent(records, "datetime_measured")

--- a/backend/connectors/usgs/source.py
+++ b/backend/connectors/usgs/source.py
@@ -163,7 +163,7 @@ class NWISWaterLevelSource(BaseWaterLevelSource):
 
     def _extract_parameter_results(self, records):
         return [float(r["value"]) for r in records]
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         return [r["datetime_measured"] for r in records]
 

--- a/backend/connectors/wqp/source.py
+++ b/backend/connectors/wqp/source.py
@@ -119,7 +119,7 @@ class WQPAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_units(self, records):
         return [ri["ResultMeasure/MeasureUnitCode"] for ri in records]
-    
+
     def _extract_parameter_dates(self, records):
         return [ri["ActivityStartDate"] for ri in records]
 

--- a/backend/connectors/wqp/source.py
+++ b/backend/connectors/wqp/source.py
@@ -119,6 +119,9 @@ class WQPAnalyteSource(BaseAnalyteSource):
 
     def _extract_parameter_units(self, records):
         return [ri["ResultMeasure/MeasureUnitCode"] for ri in records]
+    
+    def _extract_parameter_dates(self, records):
+        return [ri["ActivityStartDate"] for ri in records]
 
     def _extract_most_recent(self, records):
         ri = get_most_recent(records, "ActivityStartDate")

--- a/backend/logging.py
+++ b/backend/logging.py
@@ -25,17 +25,16 @@ class Loggable:
 
     def log(self, msg, level=None, fg="yellow"):
         if level is None:
-            level=logging.INFO
+            level = logging.INFO
 
         click.secho(f"{self.__class__.__name__:30s}{msg}", fg=fg)
         self.logger.log(level, msg)
 
-    def warn(self, msg, fg='red'):
+    def warn(self, msg, fg="red"):
         self.log(msg, fg=fg, level=logging.WARNING)
 
     def debug(self, msg):
-        self.log(msg, level=logging.DEBUG, fg='blue')
-
+        self.log(msg, level=logging.DEBUG, fg="blue")
 
 
 def setup_logging(level=None, log_format=None, path=None):
@@ -63,4 +62,6 @@ def setup_logging(level=None, log_format=None, path=None):
         hi.setLevel(level)
         hi.setFormatter(fmt)
         root.addHandler(hi)
+
+
 # ============= EOF =============================================

--- a/backend/persister.py
+++ b/backend/persister.py
@@ -18,12 +18,10 @@ import io
 import os
 import shutil
 
-import click
 import pandas as pd
 import geopandas as gpd
 
 from backend.logging import Loggable
-from backend.record import SiteRecord
 
 try:
     from google.cloud import storage
@@ -40,8 +38,6 @@ class BasePersister(Loggable):
         self.combined = []
         self.timeseries = []
         self.sites = []
-        self.logs = []
-        self.warnings = []
 
         super().__init__()
         # self.keys = record_klass.keys
@@ -97,24 +93,6 @@ class BasePersister(Loggable):
             self._write(path, self.sites)
         else:
             self.log("no sites to dump", fg="red")
-
-    def dump_logs(self, path: str):
-        if self.logs:
-            self.log(f"dumping logs to {os.path.abspath(path)}")
-            with open(path, "w") as f:
-                for l in self.logs:
-                    f.write(f"{l}\n")
-        else:
-            self.log("no logs to dump")
-
-    def dump_warnings(self, path: str):
-        if self.warnings:
-            self.log(f"dumping warnings to {os.path.abspath(path)}")
-            with open(path, "w") as f:
-                for w in self.warnings:
-                    f.write(f"{w}\n")
-        else:
-            self.log("no warnings to dump")
 
     def save(self, path: str):
         if self.records:

--- a/backend/persister.py
+++ b/backend/persister.py
@@ -31,8 +31,6 @@ except ImportError:
     print("google cloud storage not available")
 
 
-
-
 class BasePersister(Loggable):
     extension: str
     # output_id: str

--- a/backend/source.py
+++ b/backend/source.py
@@ -681,7 +681,7 @@ class BaseParameterSource(BaseSource):
                                 u,
                                 self._get_output_units(),
                                 self.config.analyte,
-                                d
+                                d,
                             )
                             if warning_msg == "":
                                 kept_items.append(converted_result)
@@ -874,7 +874,7 @@ class BaseParameterSource(BaseSource):
         raise NotImplementedError(
             f"{self.__class__.__name__} Must implement _extract_parameter_units"
         )
-    
+
     def _extract_parameter_dates(self, records: list) -> list:
         """
         Returns the dates of the parameter records as a list, in the same order as the records themselves

--- a/backend/source.py
+++ b/backend/source.py
@@ -1015,4 +1015,13 @@ class BaseWaterLevelSource(BaseParameterSource):
                 raise ValueError(f"Invalid record. Missing {k}")
 
 
+class BaseFileSource(BaseSource):
+    """
+    Base class for all file sources
+    """
+
+    name = "files"
+
+    
+
 # ============= EOF =============================================

--- a/backend/source.py
+++ b/backend/source.py
@@ -672,14 +672,16 @@ class BaseParameterSource(BaseSource):
 
                     results = self._extract_parameter_results(cleaned)
                     units = self._extract_parameter_units(cleaned)
+                    dates = self._extract_parameter_dates(cleaned)
 
-                    for r, u in zip(results, units):
+                    for r, u, d in zip(results, units, dates):
                         try:
                             converted_result, warning_msg = convert_units(
                                 float(r),
                                 u,
                                 self._get_output_units(),
                                 self.config.analyte,
+                                d
                             )
                             if warning_msg == "":
                                 kept_items.append(converted_result)
@@ -871,6 +873,24 @@ class BaseParameterSource(BaseSource):
         """
         raise NotImplementedError(
             f"{self.__class__.__name__} Must implement _extract_parameter_units"
+        )
+    
+    def _extract_parameter_dates(self, records: list) -> list:
+        """
+        Returns the dates of the parameter records as a list, in the same order as the records themselves
+
+        Parameters
+        ----------
+        records: list
+            a list of parameter records
+
+        Returns
+        -------
+        list
+            a list of dates for the parameter records in the same order as the records
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} Must implement _extract_parameter_dates"
         )
 
     def _extract_parameter_record(self, record: dict) -> dict:

--- a/backend/source.py
+++ b/backend/source.py
@@ -1022,6 +1022,5 @@ class BaseFileSource(BaseSource):
 
     name = "files"
 
-    
 
 # ============= EOF =============================================

--- a/backend/transformer.py
+++ b/backend/transformer.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 import click
 import pprint
-from datetime import datetime
+from datetime import datetime, date, timedelta
 
 import shapely
 from shapely import Point
@@ -260,12 +260,20 @@ def standardize_datetime(dt):
             "%Y/%m/%d %H:%M:%S",
             "%Y/%m/%d %H:%M",
             "%Y/%m/%d",
+            "%m/%d/%Y"
         ]:
             try:
                 dt = datetime.strptime(dt.split(".")[0], fmt)
                 break
             except ValueError as e:
-                pass
+                try:
+                    # Ft Sumner (OSE Roswell) reports Excel date numbers
+                    num_days_to_add = int(dt)
+                    base_date = date(1900, 1, 1)
+                    dt = base_date + timedelta(days=num_days_to_add)
+                    break
+                except ValueError as e:
+                    pass
         else:
             raise ValueError(f"Failed to parse datetime {dt}")
 

--- a/backend/transformer.py
+++ b/backend/transformer.py
@@ -260,7 +260,7 @@ def standardize_datetime(dt):
             "%Y/%m/%d %H:%M:%S",
             "%Y/%m/%d %H:%M",
             "%Y/%m/%d",
-            "%m/%d/%Y"
+            "%m/%d/%Y",
         ]:
             try:
                 dt = datetime.strptime(dt.split(".")[0], fmt)

--- a/backend/transformer.py
+++ b/backend/transformer.py
@@ -425,6 +425,11 @@ class BaseTransformer(Loggable):
         if isinstance(record, (SiteRecord, SummaryRecord)):
             y = float(record.latitude)
             x = float(record.longitude)
+
+            if x == 0 or y == 0:
+                self.warn(f"Skipping site {record.id}. Latitude or Longitude is 0")
+                return None
+
             input_horizontal_datum = record.horizontal_datum
 
             if input_horizontal_datum not in ALLOWED_DATUMS:

--- a/backend/transformer.py
+++ b/backend/transformer.py
@@ -119,7 +119,11 @@ def transform_length_units(
 
 
 def convert_units(
-    input_value: int | float | str, input_units: str, output_units: str, analyte: str, dt: str = None
+    input_value: int | float | str,
+    input_units: str,
+    output_units: str,
+    analyte: str,
+    dt: str = None,
 ) -> float:
     """
     Converts the following units for any parameter value:
@@ -464,7 +468,11 @@ class BaseTransformer:
             warning_msg = ""
             try:
                 converted_result, warning_msg = convert_units(
-                    float(r), u, self.config.analyte_output_units, self.config.analyte, dt
+                    float(r),
+                    u,
+                    self.config.analyte_output_units,
+                    self.config.analyte,
+                    dt,
                 )
                 if warning_msg != "":
                     msg = f"{warning_msg} for {record.id}"

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -186,7 +186,6 @@ def _site_wrapper(site_source, parameter_source, persister, config):
         config.warn(f"Failed to unify {site_source}")
 
 
-
 def _unify_parameter(
     config,
     sources,

--- a/backend/unifier.py
+++ b/backend/unifier.py
@@ -41,7 +41,7 @@ def health_check(source: BaseSiteSource) -> bool:
 
 
 def unify_sites(config):
-    print("Unifying sites")
+    print("Unifying sites\n")
 
     # def func(config, persister):
     #     for source in config.site_sources():
@@ -52,8 +52,8 @@ def unify_sites(config):
 
 
 def unify_analytes(config):
-    print("Unifying analytes")
-    config.report(log_report=True)
+    print("Unifying analytes\n")
+    # config.report() -- report is done in cli.py, no need to do it twice
     config.validate()
 
     if not config.dry:
@@ -63,9 +63,9 @@ def unify_analytes(config):
 
 
 def unify_waterlevels(config):
-    print("Unifying waterlevels")
+    print("Unifying waterlevels\n")
 
-    config.report(log_report=True)
+    # config.report() -- report is done in cli.py, no need to do it twice
     config.validate()
 
     if not config.dry:
@@ -182,14 +182,9 @@ def _site_wrapper(site_source, parameter_source, persister, config):
         import traceback
 
         exc = traceback.format_exc()
-        print(exc)
-        print(f"Failed to unify {site_source}")
+        config.warn(exc)
+        config.warn(f"Failed to unify {site_source}")
 
-        config.logs.append(exc)
-        config.logs.append(f"Failed to unify {site_source}")
-
-        config.warnings.append(exc)
-        config.warnings.append(f"Failed to unify {site_source}")
 
 
 def _unify_parameter(
@@ -209,10 +204,6 @@ def _unify_parameter(
         persister.dump_combined(f"{config.output_path}.combined")
         persister.dump_timeseries(f"{config.output_path}_timeseries")
 
-    persister.logs.extend(config.logs)
-    persister.warnings.extend(config.warnings)
-    persister.dump_logs(f"{config.output_path}.logs.txt")
-    persister.dump_warnings(f"{config.output_path}.warnings.txt")
     persister.finalize(config.output_name)
 
 

--- a/frontend/cli.py
+++ b/frontend/cli.py
@@ -139,14 +139,14 @@ DT_OPTIONS = [
 
 TIMESERIES_OPTIONS = [
     click.option(
-        "--separate_timeseries_files",
+        "--separated_timeseries",
         is_flag=True,
         default=False,
         show_default=True,
         help="Output separate timeseries files for every site",
     ),
     click.option(
-        "--single_timeseries_file",
+        "--unified_timeseries",
         is_flag=True,
         default=False,
         show_default=True,
@@ -182,8 +182,8 @@ def wells(bbox, county):
 @add_options(SOURCE_OPTIONS)
 @add_options(DEBUG_OPTIONS)
 def waterlevels(
-    separate_timeseries_files,
-    single_timeseries_file,
+    separated_timeseries,
+    unified_timeseries,
     start_date,
     end_date,
     bbox,
@@ -200,13 +200,13 @@ def waterlevels(
     site_limit,
     dry,
 ):
-    if separate_timeseries_files or single_timeseries_file:
+    if separated_timeseries or unified_timeseries:
         timeseries = True
     else:
         timeseries = False
     config = setup_config("waterlevels", timeseries, bbox, county, site_limit, dry)
 
-    config.output_single_timeseries = single_timeseries_file
+    config.output_single_timeseries = unified_timeseries
     config.use_source_nmbgmr = no_amp
     config.use_source_nwis = no_nwis
     config.use_source_pvacd = no_pvacd
@@ -238,8 +238,8 @@ def waterlevels(
 @add_options(DEBUG_OPTIONS)
 def analytes(
     analyte,
-    separate_timeseries_files,
-    single_timeseries_file,
+    separated_timeseries,
+    unified_timeseries,
     start_date,
     end_date,
     bbox,
@@ -256,7 +256,7 @@ def analytes(
     site_limit,
     dry,
 ):
-    if separate_timeseries_files or single_timeseries_file:
+    if separated_timeseries or unified_timeseries:
         timeseries = True
     else:
         timeseries = False
@@ -265,7 +265,7 @@ def analytes(
     )
     config.analyte = analyte
 
-    config.output_single_timeseries = single_timeseries_file
+    config.output_single_timeseries = unified_timeseries
     config.use_source_nmbgmr = no_amp
     config.use_source_nwis = no_nwis
     config.use_source_pvacd = no_pvacd

--- a/frontend/cli.py
+++ b/frontend/cli.py
@@ -22,8 +22,8 @@ from backend.constants import ANALYTE_CHOICES
 from backend.unifier import unify_sites, unify_waterlevels, unify_analytes
 
 from backend.logging import setup_logging
-setup_logging()
 
+setup_logging()
 
 
 @click.group()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ geopandas
 frost_sta_client
 google-cloud-storage
 pytest
+urllib3>=2.2.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="nmuwd",
-    version="0.1.0",
+    version="0.2.0",
     author="Jake Ross",
     description="New Mexico Water Data Integration Engine",
     long_description=long_description,


### PR DESCRIPTION
**Updated Logging**
- Implemented Python's logging library throughout and deprecated all instances of the old logging system

**Updated timeseries flags**
- Time series data can now be requested by `--separated_timeseries` and `--unified_timeseries`. The former creates individual files for every site, whereas the latter creates one unified file for all sites

**Excel-style dates**
- Some PVACD dates are reported in a format particular to Excel. Those are now accounted for

**Removal of records with invalid location data**
- Removed records where latitude or longitude are reported as 0

**Updated README**
- Updated README.md to account for
    - More analytes
    - `--bbox` needed to be input as `--bbox 'x1 y1, x2 y2`
    - `--start_date` and `end_date` should be input as `YYYY-MM-DD`
    - Which sources report report water level data and which sources report analyte data
    - Output file headers
    - How to get in touch to add data sources